### PR TITLE
Add logging flags to kingpin app

### DIFF
--- a/s3_exporter.go
+++ b/s3_exporter.go
@@ -175,7 +175,7 @@ func main() {
 		forcePathStyle = app.Flag("s3.force-path-style", "Custom force path style").Bool()
 	)
 
-	log.AddFlags(kingpin.CommandLine)
+	log.AddFlags(app)
 	app.Version(version.Print(namespace + "_exporter"))
 	app.HelpFlag.Short('h')
 	kingpin.MustParse(app.Parse(os.Args[1:]))


### PR DESCRIPTION
At some point we switched to using a custom kingpin app rather than the base one but we didn't update the app in `log.AddFlags`.