### PR TITLE
CI: push multiarch Docker images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to Docker Hub
@@ -24,6 +26,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64, linux/arm, linux/amd64
   snapshot:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This commit modifies the CI configuration so that the containers that
are built are actually manifest lists with images for multiple
architectures, not just AMD64. This is helpful for modern clouds and
hybrid clusters, where it's possible that not all machines are AMD64.

I think this should work out of the box, since the `s3_exporter` binaries
are built in the container itself, and the `golang` images are all multiarch.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>