### PR TITLE
add missing label when ListObjectsV2 call returns an error

### DIFF
--- a/s3_exporter.go
+++ b/s3_exporter.go
@@ -110,7 +110,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		if err != nil {
 			log.Errorln(err)
 			ch <- prometheus.MustNewConstMetric(
-				s3ListSuccess, prometheus.GaugeValue, 0, e.bucket, e.prefix,
+				s3ListSuccess, prometheus.GaugeValue, 0, e.bucket, e.prefix, e.delimiter,
 			)
 			return
 		}


### PR DESCRIPTION
This fixes a panic occuring when the ListObjectsV2 call returns an error (bucket does not exist, user not authorized, ...).

```
INFO[0000] Listening on :9340                            source="s3_exporter.go:301"
ERRO[0014] NoSuchBucket: The specified bucket does not exist
        status code: 404, request id: 16F4DB470BC51C7C, host id:   source="s3_exporter.go:112"
panic: inconsistent label cardinality: expected 3 label values but got 2 in []string{"foobar", ""}

goroutine 39 [running]:
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
        /home/pheng/Git/github/s3_exporter/vendor/github.com/prometheus/client_golang/prometheus/value.go:107
main.(*Exporter).Collect(0xc000310440, 0xc000370f60?)
        /home/pheng/Git/github/s3_exporter/s3_exporter.go:113 +0x3eb
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
        /home/pheng/Git/github/s3_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:444 +0xfb
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
        /home/pheng/Git/github/s3_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:455 +0x4c5
```