### PR TITLE
Add ability to evaluate versioned buckets

### DIFF
--- a/s3_exporter_test.go
+++ b/s3_exporter_test.go
@@ -135,6 +135,173 @@ var (
 				},
 			},
 		},
+		// Test one versioned object in a bucket on latest version
+		s3ExporterTestCase{
+			Name:   "one object",
+			Bucket: "mock-versioned",
+			Prefix: "one",
+			ExpectedOutputLines: []string{
+				"s3_list_success{bucket=\"mock-versioned\",delimiter=\"\",prefix=\"one\"} 1",
+				"s3_last_modified_object_date{bucket=\"mock-versioned\",prefix=\"one\"} 1.5604596e+09",
+				"s3_last_modified_object_size_bytes{bucket=\"mock-versioned\",prefix=\"one\"} 1234",
+				"s3_biggest_object_size_bytes{bucket=\"mock-versioned\",prefix=\"one\"} 1234",
+				"s3_objects_size_sum_bytes{bucket=\"mock-versioned\",prefix=\"one\"} 1234",
+				"s3_objects{bucket=\"mock-versioned\",prefix=\"one\"} 1",
+			},
+			ListObjectVersionsResponse: &s3.ListObjectVersionsOutput{
+				Versions: []*s3.ObjectVersion{
+					&s3.ObjectVersion{
+						Key:          String("one"),
+						LastModified: Time(time.Date(2019, time.June, 13, 21, 0, 0, 0, time.UTC)),
+						Size:         Int64(1234),
+						IsLatest:     Bool(true),
+					},
+				},
+				IsTruncated: Bool(false),
+				MaxKeys:     Int64(1000),
+				Name:        String("mock-versioned"),
+				Prefix:      String("one"),
+			},
+		},
+		// Test one versioned object in a bucket with multiple versions
+		s3ExporterTestCase{
+			Name:   "one object - two versions",
+			Bucket: "mock-versioned",
+			Prefix: "two-versions",
+			ExpectedOutputLines: []string{
+				"s3_list_success{bucket=\"mock-versioned\",delimiter=\"\",prefix=\"two-versions\"} 1",
+				"s3_last_modified_object_date{bucket=\"mock-versioned\",prefix=\"two-versions\"} 1.5604596e+09",
+				"s3_last_modified_object_size_bytes{bucket=\"mock-versioned\",prefix=\"two-versions\"} 1234",
+				"s3_biggest_object_size_bytes{bucket=\"mock-versioned\",prefix=\"two-versions\"} 2345",
+				"s3_objects_size_sum_bytes{bucket=\"mock-versioned\",prefix=\"two-versions\"} 3579",
+				"s3_objects{bucket=\"mock-versioned\",prefix=\"two-versions\"} 2",
+			},
+			ListObjectVersionsResponse: &s3.ListObjectVersionsOutput{
+				Versions: []*s3.ObjectVersion{
+					&s3.ObjectVersion{
+						Key:          String("one"),
+						LastModified: Time(time.Date(2019, time.June, 13, 20, 0, 0, 0, time.UTC)),
+						Size:         Int64(2345),
+						IsLatest:     Bool(false),
+					},
+					&s3.ObjectVersion{
+						Key:          String("one"),
+						LastModified: Time(time.Date(2019, time.June, 13, 21, 0, 0, 0, time.UTC)),
+						Size:         Int64(1234),
+						IsLatest:     Bool(true),
+					},
+				},
+				IsTruncated: Bool(false),
+				MaxKeys:     Int64(1000),
+				Name:        String("mock-versioned"),
+				Prefix:      String("one"),
+			},
+		},
+		s3ExporterTestCase{
+			Name:   "no objects versioned",
+			Bucket: "mock-versioned",
+			Prefix: "none",
+			ExpectedOutputLines: []string{
+				"s3_biggest_object_size_bytes{bucket=\"mock-versioned\",prefix=\"none\"} 0",
+				"s3_last_modified_object_date{bucket=\"mock-versioned\",prefix=\"none\"} -6.795364578e+09",
+				"s3_last_modified_object_size_bytes{bucket=\"mock-versioned\",prefix=\"none\"} 0",
+				"s3_list_success{bucket=\"mock-versioned\",delimiter=\"\",prefix=\"none\"} 1",
+				"s3_objects_size_sum_bytes{bucket=\"mock-versioned\",prefix=\"none\"} 0",
+				"s3_objects{bucket=\"mock-versioned\",prefix=\"none\"} 0",
+			},
+			ListObjectVersionsResponse: &s3.ListObjectVersionsOutput{
+				Versions:    []*s3.ObjectVersion{},
+				IsTruncated: Bool(false),
+				MaxKeys:     Int64(1000),
+				Name:        String("mock-versioned"),
+				Prefix:      String("none"),
+			},
+		},
+		s3ExporterTestCase{
+			Name:   "multiple objects - multiple versions",
+			Bucket: "mock-versioned",
+			Prefix: "multiple",
+			ExpectedOutputLines: []string{
+				"s3_list_success{bucket=\"mock-versioned\",delimiter=\"\",prefix=\"multiple\"} 1",
+				"s3_last_modified_object_date{bucket=\"mock-versioned\",prefix=\"multiple\"} 1.5604596e+09",
+				"s3_last_modified_object_size_bytes{bucket=\"mock-versioned\",prefix=\"multiple\"} 3332",
+				"s3_biggest_object_size_bytes{bucket=\"mock-versioned\",prefix=\"multiple\"} 3333",
+				"s3_objects_size_sum_bytes{bucket=\"mock-versioned\",prefix=\"multiple\"} 13331",
+				"s3_objects{bucket=\"mock-versioned\",prefix=\"multiple\"} 6",
+			},
+			ListObjectVersionsResponse: &s3.ListObjectVersionsOutput{
+				Versions: []*s3.ObjectVersion{
+					&s3.ObjectVersion{
+						Key:          String("mulitple/abc/0"),
+						LastModified: Time(time.Date(2019, time.June, 13, 19, 0, 0, 0, time.UTC)),
+						Size:         Int64(3333),
+						IsLatest:     Bool(false),
+					},
+					&s3.ObjectVersion{
+						Key:          String("multiple1"),
+						LastModified: Time(time.Date(2019, time.June, 13, 19, 0, 0, 0, time.UTC)),
+						Size:         Int64(1111),
+						IsLatest:     Bool(false),
+					},
+					&s3.ObjectVersion{
+						Key:          String("mulitple2"),
+						LastModified: Time(time.Date(2019, time.June, 13, 20, 30, 0, 0, time.UTC)),
+						Size:         Int64(2222),
+						IsLatest:     Bool(true),
+					},
+					&s3.ObjectVersion{
+						Key:          String("mulitple1"),
+						LastModified: Time(time.Date(2019, time.June, 13, 20, 0, 0, 0, time.UTC)),
+						Size:         Int64(1112),
+						IsLatest:     Bool(true),
+					},
+					&s3.ObjectVersion{
+						Key:          String("mulitple/abc/0"),
+						LastModified: Time(time.Date(2019, time.June, 13, 21, 0, 0, 0, time.UTC)),
+						Size:         Int64(3332),
+						IsLatest:     Bool(true),
+					},
+					&s3.ObjectVersion{
+						Key:          String("mulitple2"),
+						LastModified: Time(time.Date(2019, time.June, 13, 8, 0, 0, 0, time.UTC)),
+						Size:         Int64(2221),
+						IsLatest:     Bool(false),
+					},
+				},
+				IsTruncated: Bool(false),
+				MaxKeys:     Int64(1000),
+				Name:        String("mock-versioned"),
+				Prefix:      String("multiple"),
+			},
+		},
+		// Test delimiter versioned
+		s3ExporterTestCase{
+			Name:      "common prefixes - versioned",
+			Bucket:    "mock-versioned",
+			Prefix:    "mock-prefix",
+			Delimiter: "/",
+			ExpectedOutputLines: []string{
+				"s3_list_success{bucket=\"mock-versioned\",delimiter=\"/\",prefix=\"mock-prefix\"} 1",
+				"s3_common_prefixes{bucket=\"mock-versioned\",delimiter=\"/\",prefix=\"mock-prefix\"} 3",
+			},
+			ListObjectVersionsResponse: &s3.ListObjectVersionsOutput{
+				CommonPrefixes: []*s3.CommonPrefix{
+					{
+						Prefix: String("one"),
+					},
+					{
+						Prefix: String("two"),
+					},
+					{
+						Prefix: String("three"),
+					},
+				},
+				IsTruncated: Bool(false),
+				MaxKeys:     Int64(1000),
+				Name:        String("mock-versioned"),
+				Prefix:      String("mock-prefix"),
+			},
+		},
 	}
 )
 
@@ -143,12 +310,13 @@ type mockS3Client struct {
 }
 
 type s3ExporterTestCase struct {
-	Name                  string
-	Bucket                string
-	Prefix                string
-	Delimiter             string
-	ExpectedOutputLines   []string
-	ListObjectsV2Response *s3.ListObjectsV2Output
+	Name                       string
+	Bucket                     string
+	Prefix                     string
+	Delimiter                  string
+	ExpectedOutputLines        []string
+	ListObjectsV2Response      *s3.ListObjectsV2Output
+	ListObjectVersionsResponse *s3.ListObjectVersionsOutput
 }
 
 // testBody tests the body returned by the exporter against the expected output
@@ -174,10 +342,21 @@ func (tcs *s3ExporterTestCases) response(bucket, prefix string) (*s3.ListObjects
 	return nil, errors.New("Can't find a response for the bucket and prefix combination")
 }
 
+// Returns the mocked response for a bucket+prefix combination with versioning
+func (tcs *s3ExporterTestCases) responseWithVersioning(bucket, prefix string) (*s3.ListObjectVersionsOutput, error) {
+	for _, c := range *tcs {
+		if c.Bucket == bucket && c.Prefix == prefix && c.ListObjectVersionsResponse != nil {
+			return c.ListObjectVersionsResponse, nil
+		}
+	}
+
+	return nil, errors.New("Can't find a response for the bucket and prefix combination")
+}
+
 // TestProbeHandler iterates over a list of test cases
 func TestProbeHandler(t *testing.T) {
 	for _, c := range testCases {
-		rr, err := probe(c.Bucket, c.Prefix, c.Delimiter)
+		rr, err := probe(c.Bucket, c.Prefix, c.Delimiter, c.ListObjectVersionsResponse != nil)
 		if err != nil {
 			t.Errorf(err.Error())
 		}
@@ -196,8 +375,18 @@ func (m *mockS3Client) ListObjectsV2(input *s3.ListObjectsV2Input) (*s3.ListObje
 	return r, nil
 }
 
+// ListObjectVersions mocks out the corresponding function in the S3 client, returning the response that corresponds to the test case
+func (m *mockS3Client) ListObjectVersions(input *s3.ListObjectVersionsInput) (*s3.ListObjectVersionsOutput, error) {
+	r, err := testCases.responseWithVersioning(*input.Bucket, *input.Prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
 // Repeatable probe function
-func probe(bucket, prefix, delimiter string) (rr *httptest.ResponseRecorder, err error) {
+func probe(bucket, prefix, delimiter string, versions bool) (rr *httptest.ResponseRecorder, err error) {
 	uri := "/probe?bucket=" + bucket
 	if len(prefix) > 0 {
 		uri = uri + "&prefix=" + prefix
@@ -212,7 +401,7 @@ func probe(bucket, prefix, delimiter string) (rr *httptest.ResponseRecorder, err
 
 	rr = httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		probeHandler(w, r, mockSvc)
+		probeHandler(w, r, mockSvc, versions)
 	})
 
 	handler.ServeHTTP(rr, req)


### PR DESCRIPTION
Summary:

This PR adds the ability for users to list and evaluate all versioned objects in the bucket. The existing behavior was using ListObjectsV2 API which only listed current/latest objects on a versioned bucket. As a result all the metrics did not account for older versions of objects which were present on the bucket and taking up space. For my use case this was unacceptable, as I need to know when I'm approaching the storage limit of my bucket.

In order to address this a few changes were introduced:

1. Provide a new flag `--s3.with-versions` which changes the behavior of the API calls and is purely opt in (default is false) which maintains backwards compatibility.
2. Abstract away the counters into a new `ItemAggregator` struct which keeps track of statistics and define a separate parallel method on how to evaluate all objects in a bucket using ListObjectVersions API.
3. Select between 2 different implementations (CountViaListObjectsV2 and CountViaListObjectVersions) the appropriate method based on the flag.
4. Extend test case semantics to support the new API usage and write additional unit tests to exercise them.

Further things of note:
1. Right now, the flag is global and not per bucket. This is ok, because ListObjectVersions is backwards compatible with non-versioned buckets and will function just as well with any bucket. Otherwise, we would also have to query the bucket versioning status.
2. In integ testing, on my S3 Provider (E2 idrive) the ListObjectVersions API performs about 10-15% slower for the same non-versioned bucket. Obviously for a versioned bucket the difference can be much much bigger. This matters if the evaluation time is close to the job timeout in Prometheus (i.e. you have a huge bucket with a lot of objects).

Tested on my account end to end across 3 different buckets (versioned, non-versioned, empty non-versioned).

Happy to consider any changes you want me to make or any other suggestions you might have.